### PR TITLE
"try" to manage the use case for avoid to merge by quantity crafted item with non crafted item

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ interface System extends SystemApi {
     currenciesSum:(source: Currencies, add: Currencies, doExchange:boolean)=>Currencies
     objectAttributeGet:(obj:any, attribute:string, fallback?:any)=>any,
     objectAttributeSet:(obj:any, attribute:string, value)=>void,
-    itemListComponentFind:(itemList,component: ComponentData)=>{components:Component[],quantity:number},
+    itemListComponentFind:(itemList,component: ComponentData, isACraftingResult?:boolean)=>{components:Component[],quantity:number},
     tokenMovementCreate:(actorId:string)=>TokenMovementInstance,
     uiDialogSelect:(data: SelectData)=>Promise<string>
 }


### PR DESCRIPTION
The use case I have a "dagger" in the inventory, but I craft one with a recipe (thus having the "beaver-crafting" flags), the two "daggers" for the current name check "merge" increased the quantity attribute resulting in both being crafted.

I have put in my own solution, but since it is a function used on your core instead of on the "beaver-crafting" module itself, I don't know if it is the most correct one.